### PR TITLE
testing cnames

### DIFF
--- a/feathers/ops.yml
+++ b/feathers/ops.yml
@@ -1,10 +1,10 @@
 version: "1"
 services:
-  - name: feathers:0.1.0
+  - name: feathers:0.1.1
     sdk: "2"
     run: npm start
     public: false
     description: A feathers example
-    cname: ""
+    cname: "feathers.cto.ai"
     remote: true
     port: [ '8080:8080' ]


### PR DESCRIPTION
Testing `CNAME` configuration for different DNS providers.

- [x] cloudflare - _note:_ **does support** `CNAME` as`ALIAS` for Apex. Must be set to `DNS only` not `proxied`
- [x] namecheap - _note:_ **does not** support `CNAME` as `ALIAS` for Apex domain. `A` requires Static IP.
- [ ] route 53
- [ ] iwantmyname.com
- [ ] godaddy.com

... need to pull a list from a competitor of other major DNS providers to test against.